### PR TITLE
Update Vertex2Portal Converter.ms

### DIFF
--- a/Vertex2Portal Converter.ms
+++ b/Vertex2Portal Converter.ms
@@ -9,7 +9,7 @@ rollout MKTools "Vertex2Portal Converter"
 	(	
 		try
         for i in $.selectedVerts do (
-            vertexText.text += i.pos.x as string + ", " + i.pos.y as string + ", " + i.pos.z as string + "\r\n"
+            vertexText.text += i.pos.x as string +" " + i.pos.y as string + " " + i.pos.z as string + "\r\n"
         )
 		catch
 		(


### PR DESCRIPTION
Remove the "," between the coordinates to make it easier to copy and paste into your .ytyp document and not waste time removing them